### PR TITLE
Add missing GitPython dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,14 @@ setup(
         "Development Status :: 3 - Alpha",
     ],
     packages=find_packages(),
-    install_requires=["coloredlogs", "docopt", "GitPython", "packaging",
-                      "pre_commit_hooks", "toml"],
+    install_requires=[
+        "coloredlogs",
+        "docopt",
+        "GitPython",
+        "packaging",
+        "pre_commit_hooks",
+        "toml",
+    ],
     entry_points={
         "console_scripts": [
             "require_version_bump = metovhooks.require_version_bump:main",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         "Development Status :: 3 - Alpha",
     ],
     packages=find_packages(),
-    install_requires=["coloredlogs", "docopt", "packaging", "pre_commit_hooks", "toml"],
+    install_requires=["coloredlogs", "docopt", "GitPython", "packaging",
+                      "pre_commit_hooks", "toml"],
     entry_points={
         "console_scripts": [
             "require_version_bump = metovhooks.require_version_bump:main",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="metovhooks",
-    version="0.1.3",
+    version="0.1.4",
     description="My personal git hooks.",
     url="https://github.com/metov/metovhooks",
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
I added a new script in v0.1.3 that relies on GitPython, but forgot to add the requirement to setup.py. As a result, the hooks might install incorrectly on some systems - therefore I yanked the release from PyPi. This PR adds the dependency.
