### PR TITLE
Simplify and modularize version parsing logic, fix #12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="metovhooks",
-    version="0.1.5",
+    version="0.1.6",
     description="My personal git hooks.",
     url="https://github.com/metov/metovhooks",
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
* Remove overcomplicate `Parsers` class and method selection logic, use simple if block instead
* Separate reading the file from parsing
