### PR TITLE
Fail gracefully if version parsing fails, fix #9

### DIFF
--- a/metovhooks/require_version_bump.py
+++ b/metovhooks/require_version_bump.py
@@ -80,6 +80,8 @@ class VersionParsingError(Exception):
 def parse_setup_py(contents):
     r = r"version\s*=\s*['\"]([^'\"]+)['\"]"
     m = re.search(r, contents)
+    if not m:
+        raise VersionParsingError
     return m[1]
 
 

--- a/metovhooks/require_version_bump.py
+++ b/metovhooks/require_version_bump.py
@@ -3,6 +3,7 @@ Compares the current version to the one in a baseline branch. The exit code
 will be:
 * 0 if current version is higher
 * 1 if current version is not higher
+* 2 if the version could not be parsed from given files
 
 This is intended for a workflow where you have some long living "baseline"
 branch (eg. dev) and develop features in feature branches, with the convention
@@ -60,12 +61,20 @@ def read_version_files(version_file: Path, reference_branch: str):
 
 
 def parse_version_file(contents: str, version_file_name: str) -> str:
-    if version_file_name == "setup.py":
-        return parse_setup_py(contents)
-    elif version_file_name == "pyproject.toml":
-        return parse_pyproject_toml(contents)
-    else:
-        RuntimeError(f"Don't know how to parse: {version_file_name}")
+    try:
+        if version_file_name == "setup.py":
+            return parse_setup_py(contents)
+        elif version_file_name == "pyproject.toml":
+            return parse_pyproject_toml(contents)
+        else:
+            RuntimeError(f"Don't know how to parse: {version_file_name}")
+    except VersionParsingError:
+        log.critical("No version found in file.")
+        exit(2)
+
+
+class VersionParsingError(Exception):
+    pass
 
 
 def parse_setup_py(contents):

--- a/metovhooks/require_version_bump.py
+++ b/metovhooks/require_version_bump.py
@@ -87,7 +87,20 @@ def parse_setup_py(contents):
 
 def parse_pyproject_toml(contents):
     t = toml.loads(contents)
-    return t["tool"]["poetry"]["version"]
+
+    tool = t.get("tool")
+    if tool is None:
+        raise VersionParsingError
+
+    poetry = tool.get("poetry")
+    if poetry is None:
+        raise VersionParsingError
+
+    version = poetry.get("version")
+    if version is None:
+        raise VersionParsingError
+
+    return version
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="metovhooks",
-    version="0.1.6",
+    version="0.1.7",
     description="My personal git hooks.",
     url="https://github.com/metov/metovhooks",
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
- bump version
- add new exit code for fails on version parse
- raise exception on failure to parse setup.py
- raise exception on failure to parse poetry definition
