### PR TITLE
Parse versions to compare correctly, fix #8

### DIFF
--- a/metovhooks/require_version_bump.py
+++ b/metovhooks/require_version_bump.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import toml
 from docopt import docopt
+from packaging.version import Version
 from pre_commit_hooks.util import cmd_output
 
 from metovhooks import log
@@ -39,9 +40,8 @@ def check_version(version_file, base_branch):
     cur_raw = parse_version_file(cur_file, version_file.name)
     ref_raw = parse_version_file(ref_file, version_file.name)
 
-    # TODO: Actually parse the version here
-    cur_ver = cur_raw
-    ref_ver = ref_raw
+    cur_ver = Version(cur_raw)
+    ref_ver = Version(ref_raw)
 
     if cur_ver > ref_ver:
         log.info(f"The current version {cur_ver} > {base_branch} version {ref_ver}.")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="metovhooks",
-    version="0.1.7",
+    version="0.1.8",
     description="My personal git hooks.",
     url="https://github.com/metov/metovhooks",
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
- bump version
- parse versions instead of comparing as raw strings
